### PR TITLE
(bug) Increase Resources to Tensboard Controller

### DIFF
--- a/apps/tensorboard/tensorboard-controller/upstream/manager/manager.yaml
+++ b/apps/tensorboard/tensorboard-controller/upstream/manager/manager.yaml
@@ -31,9 +31,9 @@ spec:
         name: manager
         resources:
           limits:
-            cpu: 100m
-            memory: 50Mi
+            cpu: 300m
+            memory: 200Mi
           requests:
             cpu: 100m
-            memory: 30Mi
+            memory: 100Mi
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves upstream https://github.com/kubeflow/manifests/issues/2101

**Description of your changes:**
* Increase resources so that the controller stops crashing.

**Checklist:**
- [ ] Unit tests pass: - no make file to run for this manifest?
  **Make sure you have installed kustomize == 3.2.1**
    1. `make generate-changed-only`
    2. `make test`
